### PR TITLE
Add declaration of void Config::addSubscribe(string,string,string*)

### DIFF
--- a/src/ofxSpacebrew.cpp
+++ b/src/ofxSpacebrew.cpp
@@ -133,7 +133,10 @@ namespace Spacebrew {
     void Config::addSubscribe( string name, string type ){
         subscribe.push_back( Message(name, type) );
     }
-    
+    //--------------------------------------------------------------
+    void Config::addSubscribe( string name, string type, string * value ){
+        subscribe.push_back( Message(name, type, value ) );
+    }
     //--------------------------------------------------------------
     void Config::addSubscribe( Message m ){
         subscribe.push_back(m);


### PR DESCRIPTION
Declaration of void Config::addSubscribe(string name,string type,string \* value)
is missing in ofxSpacebrew.cpp, causing link error in VS2012
